### PR TITLE
Mpr121 v3 alt detection

### DIFF
--- a/src/configuration.h
+++ b/src/configuration.h
@@ -114,13 +114,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CARDKB_ADDR 0x5F
 #define TDECK_KB_ADDR 0x55
 #define BBQ10_KB_ADDR 0x1F
-// #define MPR121_USE_5A
-#ifdef MPR121_USE_5A // Matches common 3x4 button touch boards
 #define MPR121_KB_ADDR 0x5A
-#endif
-#ifndef MPR121_USE_5A
-#define MPR121_KB_ADDR 0x5B
-#endif
 
 // -----------------------------------------------------------------------------
 // SENSOR
@@ -152,12 +146,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define DFROBOT_LARK_ADDR 0x42
 #define NAU7802_ADDR 0x2A
 #define MAX30102_ADDR 0x57
-#ifdef MPR121_USE_5A
-#define MLX90614_ADDR_DEF 0x5B // Can be adjusted by writing a new address to eeprom on the sensor
-#endif
-#ifndef MPR121_USE_5A
 #define MLX90614_ADDR_DEF 0x5A
-#endif
 
 // -----------------------------------------------------------------------------
 // ACCELEROMETER

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -411,8 +411,8 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 #endif
                 
             case MLX90614_ADDR_DEF:
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x5d), 1);
-                if (registerValue == 0x24) {
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x5c), 1);
+                if (registerValue == 0x10) {
                     type = MPR121KB;
                     LOG_INFO("MPR121KB keyboard found");
                     break;

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -411,11 +411,10 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 #endif
                 
             case MLX90614_ADDR_DEF:
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x5e), 1);
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x0e), 1);
                 if (registerValue == 0x5a) {
                     type = MLX90614;
                     LOG_INFO("MLX90614 IR temp sensor found");
-                    break;
                 } else {
                     type = MPR121KB;
                     LOG_INFO("MPR121KB keyboard found");

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -243,7 +243,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 
                 SCAN_SIMPLE_CASE(TDECK_KB_ADDR, TDECKKB, "T-Deck keyboard found");
                 SCAN_SIMPLE_CASE(BBQ10_KB_ADDR, BBQ10KB, "BB Q10 keyboard found");
-                SCAN_SIMPLE_CASE(MPR121_KB_ADDR, MPR121KB, "MPR121 keyboard found");
+                
                 SCAN_SIMPLE_CASE(ST7567_ADDRESS, SCREEN_ST7567, "st7567 display found");
 #ifdef HAS_NCP5623
                 SCAN_SIMPLE_CASE(NCP5623_ADDR, NCP5623, "NCP5623 RGB LED found");
@@ -409,7 +409,18 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 #ifdef HAS_TPS65233
                 SCAN_SIMPLE_CASE(TPS65233_ADDR, TPS65233, "TPS65233 BIAS-T found");
 #endif
-                SCAN_SIMPLE_CASE(MLX90614_ADDR_DEF, MLX90614, "MLX90614 IR temp sensor found");
+                
+            case MLX90614_ADDR_DEF:
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x5d), 1);
+                if (registerValue == 0x24) {
+                    type = MPR121KB;
+                    LOG_INFO("MPR121KB keyboard found");
+                    break;
+                } else {
+                    type = MLX90614;
+                    LOG_INFO("MLX90614 IR temp sensor found");
+                }
+                break;
 
             case ICM20948_ADDR:     // same as BMX160_ADDR
             case ICM20948_ADDR_ALT: // same as MPU6050_ADDR

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -411,14 +411,14 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 #endif
                 
             case MLX90614_ADDR_DEF:
-                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x5c), 1);
-                if (registerValue == 0x10) {
-                    type = MPR121KB;
-                    LOG_INFO("MPR121KB keyboard found");
-                    break;
-                } else {
+                registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x5e), 1);
+                if (registerValue == 0x5a) {
                     type = MLX90614;
                     LOG_INFO("MLX90614 IR temp sensor found");
+                    break;
+                } else {
+                    type = MPR121KB;
+                    LOG_INFO("MPR121KB keyboard found");
                 }
                 break;
 

--- a/src/detect/ScanI2CTwoWire.cpp
+++ b/src/detect/ScanI2CTwoWire.cpp
@@ -243,7 +243,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 
                 SCAN_SIMPLE_CASE(TDECK_KB_ADDR, TDECKKB, "T-Deck keyboard found");
                 SCAN_SIMPLE_CASE(BBQ10_KB_ADDR, BBQ10KB, "BB Q10 keyboard found");
-                
+
                 SCAN_SIMPLE_CASE(ST7567_ADDRESS, SCREEN_ST7567, "st7567 display found");
 #ifdef HAS_NCP5623
                 SCAN_SIMPLE_CASE(NCP5623_ADDR, NCP5623, "NCP5623 RGB LED found");
@@ -409,7 +409,7 @@ void ScanI2CTwoWire::scanPort(I2CPort port, uint8_t *address, uint8_t asize)
 #ifdef HAS_TPS65233
                 SCAN_SIMPLE_CASE(TPS65233_ADDR, TPS65233, "TPS65233 BIAS-T found");
 #endif
-                
+
             case MLX90614_ADDR_DEF:
                 registerValue = getRegisterValue(ScanI2CTwoWire::RegisterLocation(addr, 0x0e), 1);
                 if (registerValue == 0x5a) {

--- a/src/input/MPR121Keyboard.cpp
+++ b/src/input/MPR121Keyboard.cpp
@@ -4,12 +4,7 @@
 #include "configuration.h"
 #include <Arduino.h>
 
-#ifdef MPR121_USE_5A
 #define _MPR121_REG_KEY 0x5a
-#endif
-#ifndef MPR121_USE_5A
-#define _MPR121_REG_KEY 0x5b
-#endif
 
 #define _MPR121_REG_TOUCH_STATUS 0x00
 #define _MPR121_REG_ELECTRODE_FILTERED_DATA

--- a/src/input/MPR121Keyboard.cpp
+++ b/src/input/MPR121Keyboard.cpp
@@ -87,35 +87,12 @@ uint8_t MPR121_KeyMap[12] = {2, 5, 8, 11, 1, 4, 7, 10, 0, 3, 6, 9};
 
 MPR121Keyboard::MPR121Keyboard() : m_wire(nullptr), m_addr(0), readCallback(nullptr), writeCallback(nullptr)
 {
-    LOG_DEBUG("MPR121 @ %02x\n", m_addr);
+    // LOG_DEBUG("MPR121 @ %02x\n", m_addr);
     state = Init;
     last_key = -1;
     last_tap = 0L;
     char_idx = 0;
     queue = "";
-    status_toggle = false;
-    last_toggle = 0L;
-    last_status = false;
-}
-
-bool MPR121Keyboard::status()
-{
-    uint32_t now = millis();
-    switch (state) {
-    case Held:
-        status_toggle = true;
-        break;
-    case Idle:
-        status_toggle = false;
-        break;
-    default:
-        if ((last_toggle + 1000) < now) {
-            status_toggle = !status_toggle;
-            last_toggle = now;
-        }
-        break;
-    }
-    return status_toggle;
 }
 
 void MPR121Keyboard::begin(uint8_t addr, TwoWire *wire)
@@ -271,15 +248,6 @@ void MPR121Keyboard::trigger()
 {
     // Intended to fire in response to an interrupt from the MPR121 or a longpress callback
     // Only functional if not in Init state
-    bool next_status = status();
-    if (last_status != next_status) {
-        if (next_status) {
-            queueEvent(MPR121_FN_ON);
-        } else {
-            queueEvent(MPR121_FN_OFF);
-        };
-    }
-    last_status = next_status;
     if (state != Init) {
         // Read the key register
         uint16_t keyRegister = readRegister16(_MPR121_REG_KEY);

--- a/src/input/MPR121Keyboard.h
+++ b/src/input/MPR121Keyboard.h
@@ -17,15 +17,10 @@ class MPR121Keyboard
     int8_t last_key;
     uint32_t last_tap;
     uint8_t char_idx;
-    bool status_toggle;
-    uint32_t last_toggle;
-    bool last_status;
 
     String queue;
 
     MPR121Keyboard();
-
-    bool status();
 
     void begin(uint8_t addr = MPR121_KB_ADDR, TwoWire *wire = &Wire);
 


### PR DESCRIPTION
Removed deconfliction logic for the MPR121 and MLX IR Temp Sensor from configuration.h
Detecting MLX on address register (0x0e)
Fallback to MPR121
Some other minor improvements, cleanup.
